### PR TITLE
Modify URL of Google Python Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ A list of awesome **style guide**. The list is divided into categories such as P
 
 ## Python
 * [PEP8](https://www.python.org/dev/peps/pep-0008/)
-* [Google Style Guide](https://google.github.io/styleguide/pyguide.html)
+* [Google Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
 * [Hitchhiker's Guide to Python](http://docs.python-guide.org/en/latest/writing/style/)
 
 ## R


### PR DESCRIPTION
This URL(https://google.github.io/styleguide/pyguide.html) is deprecated.